### PR TITLE
Use ExpFloat64 for gamma distribution when k = 1

### DIFF
--- a/distribution/beta_test.go
+++ b/distribution/beta_test.go
@@ -7,9 +7,8 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-const N = 100000
-
 func TestBeta(t *testing.T) {
+	const N = 100000
 	alpha, beta := 100., 100.
 
 	var mu, sigma2 float64

--- a/distribution/gamma.go
+++ b/distribution/gamma.go
@@ -16,7 +16,7 @@ func Gamma(k, theta float64) float64 {
 
 	// 0 < k <= 1
 	// GS Algorithm
-	if k <= 1 {
+	if k < 1 {
 		for {
 			// step 1
 			u := rand.Float64()
@@ -43,25 +43,27 @@ func Gamma(k, theta float64) float64 {
 			}
 			return x * theta
 		}
-	}
-
-	// k > 1
-	// Marsaglia-Tsang Algorithm
-	d := k - 1/3.
-	c := 1 / math.Sqrt(9*d)
-	for {
-		x := rand.NormFloat64()
-		v := 1 + c*x
-		if v <= 0 {
-			continue
-		}
-		v = v * v * v
-		u := rand.Float64()
-		if u < 1-0.0331*x*x*x*x {
-			return d * v * theta
-		}
-		if math.Log(u) < 0.5*x*x+d*(1-v+math.Log(v)) {
-			return d * v * theta
+	} else if k == 1 {
+		return rand.ExpFloat64() * theta
+	} else {
+		// k > 1
+		// Marsaglia-Tsang Algorithm
+		d := k - 1/3.
+		c := 1 / math.Sqrt(9*d)
+		for {
+			x := rand.NormFloat64()
+			v := 1 + c*x
+			if v <= 0 {
+				continue
+			}
+			v = v * v * v
+			u := rand.Float64()
+			if u < 1-0.0331*x*x*x*x {
+				return d * v * theta
+			}
+			if math.Log(u) < 0.5*x*x+d*(1-v+math.Log(v)) {
+				return d * v * theta
+			}
 		}
 	}
 }

--- a/distribution/gamma_test.go
+++ b/distribution/gamma_test.go
@@ -1,0 +1,32 @@
+package distribution
+
+import (
+	"math"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGamma(t *testing.T) {
+	const N = 5000000
+
+	for _, tt := range []struct {
+		k, theta float64
+	}{
+		{0.5, 2.0},
+		{1.0, 2.0},
+		{1.5, 2.0},
+	} {
+		var mu, sigma2 float64
+		for i := 0; i < N; i++ {
+			x := Gamma(tt.k, tt.theta)
+			mu += x
+			sigma2 += x * x
+		}
+		mu = mu / N
+		sigma2 = sigma2/N - mu*mu
+
+		assert.InDelta(t, tt.k*tt.theta, mu, 0.01, "k=%f, theta=%f", tt.k, tt.theta)
+		assert.InDelta(t, tt.k*math.Pow(tt.theta, 2), sigma2, 0.01, "k=%f, theta=%f", tt.k, tt.theta)
+	}
+}


### PR DESCRIPTION
Use `rand.ExpFloat64` to reduce cpu usage for generating a gamma distributed random number with k = 1